### PR TITLE
(Re)enabled output of complex vectors in server mode (rawfile).

### DIFF
--- a/wrspice/src/fte/rawfile.cc
+++ b/wrspice/src/fte/rawfile.cc
@@ -318,7 +318,7 @@ cRawOut::file_points(int indx)
         for (int i = 0; i < ro_length; i++) {
             for (sDvList *dl = ro_dlist; dl; dl = dl->dl_next) {
                 sDataVec *v = dl->dl_dvec;
-                if (v && v->realvec()) {
+                if (v) {
                     // Don't run off the end of this vector's data
                     double dd;
                     if (i < v->length()) {
@@ -357,7 +357,7 @@ cRawOut::file_points(int indx)
             fprintf(ro_fp, " %d", indx >= 0 ? indx : i);
             for (sDvList *dl = ro_dlist; dl; dl = dl->dl_next) {
                 sDataVec *v = dl->dl_dvec;
-                if (v && v->realvec()) {
+                if (v) {
                     if (i < v->length()) {
                         if (ro_realflag)
                             fprintf(ro_fp,


### PR DESCRIPTION
Hi Steve,

Really enjoying becoming familiar with WRspice internals, thanks so much for open-sourcing this!

Something that we've noticed for some time is that in server mode, complex vectors as a result of .ac analyses are not output. Our old commercially procured version of WRspice had this property, so does the most recent version I tried.

I've made a change in fte/rawfile.cc to re-enable their output. It looks like their output was intended in the past (there's code that handles it), and maybe subsequently disabled, presumably intentionally.

What do you think, can we output complex vectors this way?

Kind regards,
Mark
