### PR TITLE
Fix build errors in fastcap/fasthenry

### DIFF
--- a/fastcap/Makefile.in
+++ b/fastcap/Makefile.in
@@ -41,6 +41,7 @@ unpack:
 	    sed -e "s/VERSION_STRING .*$$/VERSION_STRING $(VERS)/" \
 	      < fastcap-2.0wr/src/mulGlobal.h > mytmp.h; \
 	    mv -f mytmp.h fastcap-2.0wr/src/mulGlobal.h; \
+	    patch fastcap-2.0wr/src/resusage.h files/fix_resusage.patch; \
 	fi
 
 clean:

--- a/fastcap/files/fix_resusage.patch
+++ b/fastcap/files/fix_resusage.patch
@@ -1,0 +1,4 @@
+42c42
+< struct rusage timestuff;
+---
+> __attribute__((weak)) struct rusage timestuff;

--- a/fasthenry/Makefile.in
+++ b/fasthenry/Makefile.in
@@ -50,6 +50,9 @@ unpack:
 	    sed -e "s^KLU_HOME .*$$^KLU_HOME = ../../../../KLU^" \
 	        -e "s^#RTLIB .*$$^RTLIB = $(LIBRT)^" \
 	      < /tmp/mk_klu.inc > fasthenry-3.0wr/src/fasthenry/mk_klu.inc; \
+	    patch fasthenry-3.0wr/src/fasthenry/induct.c files/fix_fh_induct.patch; \
+	    patch fasthenry-3.0wr/src/fasthenry/resusage.h files/fix_fh_resusage.patch; \
+	    patch fasthenry-3.0wr/src/zbuf/resusage.h files/fix_zbuf_resusage.patch; \
 	fi
 
 clean:

--- a/fasthenry/files/fix_fh_induct.patch
+++ b/fasthenry/files/fix_fh_induct.patch
@@ -1,0 +1,40 @@
+47c47
+< FILE *fp, *fp2, *fp3, *fptemp, *fb, *fROM;
+---
+> FILE *fp1, *fp2, *fp3, *fptemp, *fb, *fROM;
+183c183
+<     fp = stdin;
+---
+>     fp1 = stdin;
+187c187
+<     fp = stdin;
+---
+>     fp1 = stdin;
+191,192c191,192
+<     fp = fopen(opts->fname, "r");
+<     if (fp == NULL) {
+---
+>     fp1 = fopen(opts->fname, "r");
+>     if (fp1 == NULL) {
+200c200
+<   err = readGeom(fp, indsys);
+---
+>   err = readGeom(fp1, indsys);
+204c204
+<   fclose(fp);
+---
+>   fclose(fp1);
+548,549c548,549
+<     fp = fopen(outfname, "wb");
+<     if (fp == NULL) {
+---
+>     fp1 = fopen(outfname, "wb");
+>     if (fp1 == NULL) {
+877c877
+<       dump_to_Ycond(fp, m, indsys);
+---
+>       dump_to_Ycond(fp1, m, indsys);
+895c895
+<     fclose(fp);
+---
+>     fclose(fp1);

--- a/fasthenry/files/fix_fh_resusage.patch
+++ b/fasthenry/files/fix_fh_resusage.patch
@@ -1,0 +1,4 @@
+53c53
+< struct rusage timestuff;
+---
+> __attribute__((weak)) struct rusage timestuff;

--- a/fasthenry/files/fix_zbuf_resusage.patch
+++ b/fasthenry/files/fix_zbuf_resusage.patch
@@ -1,0 +1,4 @@
+52c52
+< struct rusage timestuff;
+---
+> __attribute__((weak)) struct rusage timestuff;


### PR DESCRIPTION
While trying to build xictools in an up-to-date environment (gcc version 10.1.0, x86_64-pc-linux-gnu), the builds of both fastcap and fasthenry fail during linking. `ld` complains about redefinition of the `timestuff` struct, which is declared in `resusage.h` as included in multiple source files. A similar issue appears for `fp` (a generic file pointer, declared as a global variable in fasthenry and zbuf).

I was able to fix those issues by treating `timestuff` as a weak symbol and therefore share these occurences of the struct. This fixes the build for me.

Could you perhaps take a look at my fixes and/or propose another solution for this issue? I would be happy to implement them in case the current solution is not considered acceptable/the intended implementation.