### PR TITLE
Fix parallel build of KLU

### DIFF
--- a/KLU/Makefile.in
+++ b/KLU/Makefile.in
@@ -166,7 +166,7 @@ unpack:
 	@mv SuiteSparse/SuiteSparse_config .
 	-@rm -rf SuiteSparse
 
-patch:
+patch: unpack
 	@patch -p0 < long_dbl_patch
 
 depend: unpack patch


### PR DESCRIPTION
Here's another minor one (I'm trying to get this packaged for Arch Linux).

When running `make all` with a multi-CPU option (`-j8` in my case), the KLU patch fails to be applied as the `patch` and `unpack` targets are evaluated simultaneously - leading to a race condition of unpacking not having finished before patching is attempted. Putting `unpack` (though not a true file target) as a dependency of patch fixed that.