### PR TITLE
Modify 5 Makefile.in to help debug.  Use $(MAKE) -C <dir> rather than (cd <dir> ; make)

### DIFF
--- a/KLU/Makefile.in
+++ b/KLU/Makefile.in
@@ -153,7 +153,7 @@ $(SHLIB_TARGET): AMD/Lib/libamd.a BTF/Lib/libbtf.a COLAMD/Lib/libcolamd.a \
 	    $(CC) -o $(SHLIB_TARGET) $(LSHFLAG) \
  $(OFILES_AMD) $(OFILES_BTF) $(OFILES_COLAMD) $(OFILES_KLU) \
  SuiteSparse_config/SuiteSparse_config.o;
-	
+
 unpack:
 	-@rm -rf AMD BTF COLAMD KLU SuiteSparse_config
 	@tar xzf SuiteSparse-$(SSVERSION).tar.gz
@@ -164,8 +164,8 @@ unpack:
 	@mv SuiteSparse/SuiteSparse_config .
 	-@rm -rf SuiteSparse
 
-patch:
-	@patch -p0 < long_dbl_patch
+patch: unpack
+	@patch -p0 --forward < long_dbl_patch
 
 depend: unpack patch
 

--- a/mozy/Makefile.in
+++ b/mozy/Makefile.in
@@ -150,7 +150,7 @@ depend::
 	    done; \
 	fi
 	@for a in $(SUBDIRS); do \
-	  (cd $$a; $(MAKE) depend) \
+	  $(MAKE) -C $$a  depend ; \
 	done
 
 #######################################################################
@@ -164,13 +164,13 @@ eclean::
 clean:: eclean
 	-@rm -f bin/*.o
 	-@for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 
 distclean:: eclean
 	-@rm -f bin/*.o Makefile
 	-@for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) distclean) \
+	    $(MAKE) -C $$a  distclean ; \
 	done
 	-@cd packages; $(MAKE) $@
 

--- a/wrspice/Makefile.in
+++ b/wrspice/Makefile.in
@@ -113,16 +113,16 @@ MMJCO = mmjco/mmjco
 all: cptest $(TARGETS) $(MMJCO) wdemo
 
 cptest:
-	cd help; make cptest
-	cd src/misc; make cptest
-	cd src/sparse; make cptest
-	cd devlib/include; make cptest
-	cd devlib/adms/include; make cptest
+	$(MAKE) -C help cptest
+	$(MAKE) -C src/misc cptest
+	$(MAKE) -C src/sparse cptest
+	$(MAKE) -C devlib/include cptest
+	$(MAKE) -C devlib/adms/include cptest
 
 $(TARGETS)::
 	$(MAKE) bin/$@
 
-#--------------------
+#######################################################################
 # The first two targets are for Windows, create wrspice with
 # everything in a DLL, so that we can link plugins against the DLL.
 
@@ -135,7 +135,7 @@ bin/wrspice.dll: bin/wrspice.o $(LOCAL_LIBS) $(MALLOC)
 	@$(LINKCC) $(LSHFLAG) -o bin/wrspice.dll $(LFLAGS) bin/wrspice.o \
   $(LOCAL_LIBS) $(LIBS) $(MALLOC) $(STDCLIB)
 
-#--------------------
+################# end of Windows special targets ######################
 
 bin/$(NODLL_SPICE_PROG): bin/wrspice.o $(LOCAL_LIBS) $(MALLOC)
 	@echo $@: dynamic link
@@ -163,64 +163,64 @@ bin/printtoraw: bin/printtoraw.o $(BASE)/lib/miscutil.a
   $(STDCLIB) $(WINPTHREADFIX)
 
 mmjco/mmjco::
-	cd mmjco; make
+	$(MAKE) -C mmjco
 
 #######################################################################
 ####### Recursively generate libraries ################################
 
 $(DEVLIB_CALL)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 $(SUBDIR_LIBS)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 $(VLOG)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 ifeq ($(USESECURE), yes)
 $(SECURE)/secure.a::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 endif
 
 $(MALLOC)::
-	cd $(@D)/../malloc; $(MAKE)
+	$(MAKE) -C $(@D)/../malloc
 
 $(BASE)/lib/ginterf.a::
-	cd $(BASE)/ginterf; $(MAKE)
+	$(MAKE) -C $(BASE)/ginterf
 
 $(BASE)/lib/$(GRPREF)interf.a::
-	cd $(BASE)/$(GRPREF)interf; $(MAKE)
+	$(MAKE) -C $(BASE)/$(GRPREF)interf
 
 $(BASE)/lib/miscutil.a::
-	cd $(BASE)/miscutil; $(MAKE)
+	$(MAKE) -C $(BASE)/miscutil
 
 $(BASE)/lib/libregex.a::
-	cd $(BASE)/regex; $(MAKE)
+	$(MAKE) -C $(BASE)/regex
 
 ifeq ($(USEMOZY), yes)
 $(MOZY)/lib/$(GRPREF)mozy.a::
 	if [ -d $(MOZY)/src/$(GRPREF)mozy ]; then \
-	    cd $(MOZY)/src/$(GRPREF)mozy; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/$(GRPREF)mozy
 	fi
 
 $(MOZY)/lib/help.a::
 	if [ -d $(MOZY)/src/help ]; then \
-	    cd $(MOZY)/src/help; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/help
 	fi
 
 $(MOZY)/lib/htm.a::
 	if [ -d $(MOZY)/src/htm ]; then \
-	    cd $(MOZY)/src/htm; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/htm
 	fi
 
 $(MOZY)/lib/httpget.a::
 	if [ -d $(MOZY)/src/httpget ]; then \
-	    cd $(MOZY)/src/httpget; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/httpget
 	fi
 
 $(MOZY)/lib/imsave.a::
 	if [ -d $(MOZY)/src/imsave ] ; then \
-	    cd $(MOZY)/src/imsave; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/imsave
 	fi
 endif
 
@@ -274,9 +274,9 @@ CCFILES = bin/wrspice.cc bin/wrspiced.cc bin/multidec.cc bin/proc2mod.cc \
   bin/printtoraw.cc
 
 depend:
-	@(cd devlib/adms/examples; $(MAKE) make);
+	@($(MAKE) -C devlib/adms/examples
 	@for a in include $(SUBDIRS) devlib help startup; do \
-	    (cd $$a; $(MAKE) depend) \
+	    $(MAKE) -C $$a  depend ; \
 	done
 	@echo depending in $(LOCATION)
 	@if [ x$(DEPEND_DONE) = x ]; then \
@@ -302,24 +302,24 @@ eclean:
 
 clean: eclean
 	-@for a in $(SUBDIRS) devlib; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
-	cd mmjco; $(MAKE) clean
+	$(MAKE) clean -C mmjco
 	-@rm -f bin/*.o $(WDEMODIR).tar.gz
 
 distclean: eclean
 	-@for a in $(SUBDIRS) include devlib packages help startup \
   ipc_demo_files; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
-	-@cd mmjco; $(MAKE) distclean
+	-@$(MAKE) -C mmjco distclean
 	-@rm -f bin/*.o wrspice_ipc_demo.tar.gz Makefile
 	-@rm -f examples/wrspice_ipc_demo.tar.gz
 
 grclean:
-	cd src/$(GRPREF)wrs; $(MAKE) clean
-	cd ../mozy/src/$(GRPREF)mozy; $(MAKE) clean
-	cd ../xt_base/$(GRPREF)interf; $(MAKE) clean
+	$(MAKE) -C src/$(GRPREF)wrs clean
+	$(MAKE) -C ../mozy/src/$(GRPREF)mozy clean
+	$(MAKE) -C ../xt_base/$(GRPREF)interf clean
 
 #######################################################################
 ####### Install into another location #################################
@@ -474,7 +474,7 @@ $(destn)/icons::
 	done
 
 $(destn)/help::
-	cd help; $(MAKE)
+	$(MAKE) -C help
 	@$(BASE)/util/mkdirpth $@ $@/screenshots
 	help=`packages/util/wrspice_files help`; \
 	for a in $$help; do \
@@ -487,7 +487,7 @@ $(destn)/help::
 	done
 
 $(destn)/startup::
-	cd startup; $(MAKE)
+	$(MAKE) -C startup
 	@$(BASE)/util/mkdirpth $@
 	startup=`packages/util/wrspice_files startup`; \
 	for a in $$startup; do \
@@ -577,9 +577,9 @@ $(destn)/cadence-oasis::
 	fi
 
 devkit_examples:
-	(cd devlib/adms/examples; \
+	(\ -C devlib/adms/examples
 	    for a in */Makefile; do \
-	        (cd `dirname $$a`; $(MAKE) \
+	        ($(MAKE) \ -C `dirname $$a`
 	            ADMST=../../admst \
 	            ADMSXML=../../../../../adms/adms_wr/admsXml/admsXml \
 	            DLL_LOC=../../../../bin \
@@ -599,6 +599,6 @@ package::
 	if [ -n "$(TKTOOLS)" ]; then \
 	    $(MAKE) INSTALL_PREFIX=packages/root$(prefix) install_cadence; \
 	fi
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/wrspice/devlib/Makefile.in
+++ b/wrspice/devlib/Makefile.in
@@ -144,7 +144,7 @@ toc.so: toc.cc
 
 subdirs:
 	for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE)); \
+	    $(MAKE) -C $$a ; \
 	done;
 
 #######################################################################
@@ -153,7 +153,7 @@ subdirs:
 
 depend:
 	-@for a in include adms/include $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) depend;) \
+	    $(MAKE) -C $$a  depend; \
 	done
 	@echo depending in devlib
 	-@if [ x$(DEPEND_DONE) = x ]; then \
@@ -168,13 +168,13 @@ depend:
 
 clean:
 	-@for a in adms/examples $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f toc.cc *.o *.a
 
 distclean:
 	-@for a in include adms/include adms/examples  $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f toc.cc *.o *.a Makefile devices modules
 	-@rm -f adms/Makefile

--- a/xic/Makefile.in
+++ b/xic/Makefile.in
@@ -113,9 +113,9 @@ cptest:
 $(TARGETS)::
 	$(MAKE) bin/$@
 
-#--------------------
-# The first two targets are for Windows, create xic with everything in
-# a DLL, so that we can link plugins against the DLL.
+######### The first two targets are for Windows #######################
+# Create xic with everything in a DLL,
+# so that we can link plugins against the DLL.
 
 bin/$(DLL_XIC_PROG): bin/main.cc bin/xic.dll
 	$(CC) -o bin/xic bin/main.cc src/$(GRPREF)xic/resource.o -Lbin -lxic
@@ -125,7 +125,7 @@ bin/xic.dll: bin/xic.o $(LOCAL_LIBS) $(MALLOC)
 	@$(LINKCC) $(LSHFLAG) -o bin/xic.dll $(LFLAGS) bin/xic.o \
   $(LOCAL_LIBS) $(LIBS) $(MALLOC) $(STDCLIB)
 
-#--------------------
+######## end Windows specific targets. ################################
 
 bin/$(NODLL_XIC_PROG): bin/xic.o $(LOCAL_LIBS) $(MALLOC) $(OA_SUBDIR)
 	-@echo $@: dynamic link;
@@ -168,7 +168,7 @@ bin/wrdecode: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a
 	$(LINKCC) $(CFLAGS) -o bin/wrdecode $(INCLUDE) bin/cryptmain.cc \
   src/parser/parser.a $(BASE)/lib/miscutil.a  $(STDCLIB) $(WINPTHREADFIX)
 
-bin/wrsetpass: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a 
+bin/wrsetpass: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a
 	$(LINKCC) $(CFLAGS) -o bin/wrsetpass $(INCLUDE) -DENCODING -DSETPASS \
   bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a $(STDCLIB) \
   $(WINPTHREADFIX)
@@ -266,7 +266,7 @@ CCFILES = bin/xic.cc bin/sa-filetool.cc bin/cryptmain.cc
 
 depend:
 	@for a in include $(SUBDIRS) help startup plugins; do \
-	    (cd $$a; $(MAKE) depend) \
+	    $(MAKE) -C $$a  depend ; \
 	done
 	@echo depending in $(LOCATION)
 	@if [ x$(DEPEND_DONE) = x ]; then \
@@ -292,14 +292,14 @@ eclean:
 
 clean: eclean
 	-@for a in $(SUBDIRS) plugins; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f bin/*.o
 
 distclean: eclean
 	-@for a in $(SUBDIRS) src/scrkit include help startup  plugins \
   packages; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f bin/*.o Makefile
 

--- a/xt_base/Makefile.in
+++ b/xt_base/Makefile.in
@@ -29,27 +29,27 @@ SUBDIRS = \
   $(MALLOC_DIR) \
   $(REGEX_DIR)
 
-all: 
+all:
 	@if [ ! -d lib ]; then \
 	    mkdir lib; \
 	fi
 	@for a in $(SUBDIRS); do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE)) \
+	        $(MAKE) -C $$a ; \
 	    fi; \
 	done
-	
+
 depend clean:
 	-@for a in $(SUBDIRS); do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE) $@) \
+	        $(MAKE) -C $$a  $@ ; \
 	    fi; \
 	done
 
 distclean:
 	-@for a in $(SUBDIRS) packages; do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE) $@) \
+	        $(MAKE) -C $$a  $@ ; \
 	    fi; \
 	done
 	-@rm -f config.cache config.log config.status configure Makefile


### PR DESCRIPTION
From c674e30ef512a227d689aeb98fc35d2336d603e2 Mon Sep 17 00:00:00 2001
From: Gary Delp <gary.delp@slsmn.info>
Date: Mon, 27 May 2024 17:36:34 -0500
Subject: [PATCH] Change Makefile.in to use '$(MAKE) -C dir' rather than `(cd dir
 ;make) `

if one uses the pattern `$(MAKE) -C dir` then the output reflects the full flienames.
This commit/patch changes the patterns

On branch elderdelp-recursive-makes modified:   mozy/Makefile.in  wrspice/Makefile.in 	  wrspice/devlib/Makefile.in   xic/Makefile.in  xt_base/Makefile.in
'''
---
 mozy/Makefile.in           |  6 ++--
 wrspice/Makefile.in        | 72 +++++++++++++++++++-------------------
 wrspice/devlib/Makefile.in |  8 ++---
 xic/Makefile.in            | 16 ++++-----
 xt_base/Makefile.in        | 10 +++---
 5 files changed, 56 insertions(+), 56 deletions(-)

diff --git a/mozy/Makefile.in b/mozy/Makefile.in
index 2b20e4c6..4fb2f259 100644
--- a/mozy/Makefile.in
+++ b/mozy/Makefile.in
@@ -150,7 +150,7 @@ depend::
 	    done; \
 	fi
 	@for a in $(SUBDIRS); do \
-	  (cd $$a; $(MAKE) depend) \
+	  $(MAKE) -C $$a  depend ; \
 	done
 
 #######################################################################
@@ -164,13 +164,13 @@ eclean::
 clean:: eclean
 	-@rm -f bin/*.o
 	-@for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 
 distclean:: eclean
 	-@rm -f bin/*.o Makefile
 	-@for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) distclean) \
+	    $(MAKE) -C $$a  distclean ; \
 	done
 	-@cd packages; $(MAKE) $@
 
diff --git a/wrspice/Makefile.in b/wrspice/Makefile.in
index 5890b6b6..d76d83ce 100644
--- a/wrspice/Makefile.in
+++ b/wrspice/Makefile.in
@@ -113,16 +113,16 @@ MMJCO = mmjco/mmjco
 all: cptest $(TARGETS) $(MMJCO) wdemo
 
 cptest:
-	cd help; make cptest
-	cd src/misc; make cptest
-	cd src/sparse; make cptest
-	cd devlib/include; make cptest
-	cd devlib/adms/include; make cptest
+	$(MAKE) -C help cptest
+	$(MAKE) -C src/misc cptest
+	$(MAKE) -C src/sparse cptest
+	$(MAKE) -C devlib/include cptest
+	$(MAKE) -C devlib/adms/include cptest
 
 $(TARGETS)::
 	$(MAKE) bin/$@
 
-#--------------------
+#######################################################################
 # The first two targets are for Windows, create wrspice with
 # everything in a DLL, so that we can link plugins against the DLL.
 
@@ -135,7 +135,7 @@ bin/wrspice.dll: bin/wrspice.o $(LOCAL_LIBS) $(MALLOC)
 	@$(LINKCC) $(LSHFLAG) -o bin/wrspice.dll $(LFLAGS) bin/wrspice.o \
   $(LOCAL_LIBS) $(LIBS) $(MALLOC) $(STDCLIB)
 
-#--------------------
+################# end of Windows special targets ######################
 
 bin/$(NODLL_SPICE_PROG): bin/wrspice.o $(LOCAL_LIBS) $(MALLOC)
 	@echo $@: dynamic link
@@ -163,64 +163,64 @@ bin/printtoraw: bin/printtoraw.o $(BASE)/lib/miscutil.a
   $(STDCLIB) $(WINPTHREADFIX)
 
 mmjco/mmjco::
-	cd mmjco; make
+	$(MAKE) -C mmjco
 
 #######################################################################
 ####### Recursively generate libraries ################################
 
 $(DEVLIB_CALL)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 $(SUBDIR_LIBS)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 $(VLOG)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 ifeq ($(USESECURE), yes)
 $(SECURE)/secure.a::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 endif
 
 $(MALLOC)::
-	cd $(@D)/../malloc; $(MAKE)
+	$(MAKE) -C $(@D)/../malloc
 
 $(BASE)/lib/ginterf.a::
-	cd $(BASE)/ginterf; $(MAKE)
+	$(MAKE) -C $(BASE)/ginterf
 
 $(BASE)/lib/$(GRPREF)interf.a::
-	cd $(BASE)/$(GRPREF)interf; $(MAKE)
+	$(MAKE) -C $(BASE)/$(GRPREF)interf
 
 $(BASE)/lib/miscutil.a::
-	cd $(BASE)/miscutil; $(MAKE)
+	$(MAKE) -C $(BASE)/miscutil
 
 $(BASE)/lib/libregex.a::
-	cd $(BASE)/regex; $(MAKE)
+	$(MAKE) -C $(BASE)/regex
 
 ifeq ($(USEMOZY), yes)
 $(MOZY)/lib/$(GRPREF)mozy.a::
 	if [ -d $(MOZY)/src/$(GRPREF)mozy ]; then \
-	    cd $(MOZY)/src/$(GRPREF)mozy; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/$(GRPREF)mozy
 	fi
 
 $(MOZY)/lib/help.a::
 	if [ -d $(MOZY)/src/help ]; then \
-	    cd $(MOZY)/src/help; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/help
 	fi
 
 $(MOZY)/lib/htm.a::
 	if [ -d $(MOZY)/src/htm ]; then \
-	    cd $(MOZY)/src/htm; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/htm
 	fi
 
 $(MOZY)/lib/httpget.a::
 	if [ -d $(MOZY)/src/httpget ]; then \
-	    cd $(MOZY)/src/httpget; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/httpget
 	fi
 
 $(MOZY)/lib/imsave.a::
 	if [ -d $(MOZY)/src/imsave ] ; then \
-	    cd $(MOZY)/src/imsave; $(MAKE); \
+	    $(MAKE); \ -C $(MOZY)/src/imsave
 	fi
 endif
 
@@ -274,9 +274,9 @@ CCFILES = bin/wrspice.cc bin/wrspiced.cc bin/multidec.cc bin/proc2mod.cc \
   bin/printtoraw.cc
 
 depend:
-	@(cd devlib/adms/examples; $(MAKE) make);
+	@($(MAKE) -C devlib/adms/examples
 	@for a in include $(SUBDIRS) devlib help startup; do \
-	    (cd $$a; $(MAKE) depend) \
+	    $(MAKE) -C $$a  depend ; \
 	done
 	@echo depending in $(LOCATION)
 	@if [ x$(DEPEND_DONE) = x ]; then \
@@ -302,24 +302,24 @@ eclean:
 
 clean: eclean
 	-@for a in $(SUBDIRS) devlib; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
-	cd mmjco; $(MAKE) clean
+	$(MAKE) clean -C mmjco
 	-@rm -f bin/*.o $(WDEMODIR).tar.gz
 
 distclean: eclean
 	-@for a in $(SUBDIRS) include devlib packages help startup \
   ipc_demo_files; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
-	-@cd mmjco; $(MAKE) distclean
+	-@$(MAKE) -C mmjco distclean
 	-@rm -f bin/*.o wrspice_ipc_demo.tar.gz Makefile
 	-@rm -f examples/wrspice_ipc_demo.tar.gz
 
 grclean:
-	cd src/$(GRPREF)wrs; $(MAKE) clean
-	cd ../mozy/src/$(GRPREF)mozy; $(MAKE) clean
-	cd ../xt_base/$(GRPREF)interf; $(MAKE) clean
+	$(MAKE) -C src/$(GRPREF)wrs clean
+	$(MAKE) -C ../mozy/src/$(GRPREF)mozy clean
+	$(MAKE) -C ../xt_base/$(GRPREF)interf clean
 
 #######################################################################
 ####### Install into another location #################################
@@ -474,7 +474,7 @@ $(destn)/icons::
 	done
 
 $(destn)/help::
-	cd help; $(MAKE)
+	$(MAKE) -C help
 	@$(BASE)/util/mkdirpth $@ $@/screenshots
 	help=`packages/util/wrspice_files help`; \
 	for a in $$help; do \
@@ -487,7 +487,7 @@ $(destn)/help::
 	done
 
 $(destn)/startup::
-	cd startup; $(MAKE)
+	$(MAKE) -C startup
 	@$(BASE)/util/mkdirpth $@
 	startup=`packages/util/wrspice_files startup`; \
 	for a in $$startup; do \
@@ -577,9 +577,9 @@ $(destn)/cadence-oasis::
 	fi
 
 devkit_examples:
-	(cd devlib/adms/examples; \
+	(\ -C devlib/adms/examples
 	    for a in */Makefile; do \
-	        (cd `dirname $$a`; $(MAKE) \
+	        ($(MAKE) \ -C `dirname $$a`
 	            ADMST=../../admst \
 	            ADMSXML=../../../../../adms/adms_wr/admsXml/admsXml \
 	            DLL_LOC=../../../../bin \
@@ -599,6 +599,6 @@ package::
 	if [ -n "$(TKTOOLS)" ]; then \
 	    $(MAKE) INSTALL_PREFIX=packages/root$(prefix) install_cadence; \
 	fi
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################
diff --git a/wrspice/devlib/Makefile.in b/wrspice/devlib/Makefile.in
index 285971e0..2f8181f6 100644
--- a/wrspice/devlib/Makefile.in
+++ b/wrspice/devlib/Makefile.in
@@ -144,7 +144,7 @@ toc.so: toc.cc
 
 subdirs:
 	for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE)); \
+	    $(MAKE) -C $$a ; \
 	done;
 
 #######################################################################
@@ -153,7 +153,7 @@ subdirs:
 
 depend:
 	-@for a in include adms/include $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) depend;) \
+	    $(MAKE) -C $$a  depend; \
 	done
 	@echo depending in devlib
 	-@if [ x$(DEPEND_DONE) = x ]; then \
@@ -168,13 +168,13 @@ depend:
 
 clean:
 	-@for a in adms/examples $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f toc.cc *.o *.a
 
 distclean:
 	-@for a in include adms/include adms/examples  $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f toc.cc *.o *.a Makefile devices modules
 	-@rm -f adms/Makefile
diff --git a/xic/Makefile.in b/xic/Makefile.in
index 567d247c..d6a471db 100644
--- a/xic/Makefile.in
+++ b/xic/Makefile.in
@@ -113,9 +113,9 @@ cptest:
 $(TARGETS)::
 	$(MAKE) bin/$@
 
-#--------------------
-# The first two targets are for Windows, create xic with everything in
-# a DLL, so that we can link plugins against the DLL.
+######### The first two targets are for Windows #######################
+# Create xic with everything in a DLL,
+# so that we can link plugins against the DLL.
 
 bin/$(DLL_XIC_PROG): bin/main.cc bin/xic.dll
 	$(CC) -o bin/xic bin/main.cc src/$(GRPREF)xic/resource.o -Lbin -lxic
@@ -125,7 +125,7 @@ bin/xic.dll: bin/xic.o $(LOCAL_LIBS) $(MALLOC)
 	@$(LINKCC) $(LSHFLAG) -o bin/xic.dll $(LFLAGS) bin/xic.o \
   $(LOCAL_LIBS) $(LIBS) $(MALLOC) $(STDCLIB)
 
-#--------------------
+######## end Windows specific targets. ################################
 
 bin/$(NODLL_XIC_PROG): bin/xic.o $(LOCAL_LIBS) $(MALLOC) $(OA_SUBDIR)
 	-@echo $@: dynamic link;
@@ -168,7 +168,7 @@ bin/wrdecode: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a
 	$(LINKCC) $(CFLAGS) -o bin/wrdecode $(INCLUDE) bin/cryptmain.cc \
   src/parser/parser.a $(BASE)/lib/miscutil.a  $(STDCLIB) $(WINPTHREADFIX)
 
-bin/wrsetpass: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a 
+bin/wrsetpass: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a
 	$(LINKCC) $(CFLAGS) -o bin/wrsetpass $(INCLUDE) -DENCODING -DSETPASS \
   bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a $(STDCLIB) \
   $(WINPTHREADFIX)
@@ -266,7 +266,7 @@ CCFILES = bin/xic.cc bin/sa-filetool.cc bin/cryptmain.cc
 
 depend:
 	@for a in include $(SUBDIRS) help startup plugins; do \
-	    (cd $$a; $(MAKE) depend) \
+	    $(MAKE) -C $$a  depend ; \
 	done
 	@echo depending in $(LOCATION)
 	@if [ x$(DEPEND_DONE) = x ]; then \
@@ -292,14 +292,14 @@ eclean:
 
 clean: eclean
 	-@for a in $(SUBDIRS) plugins; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f bin/*.o
 
 distclean: eclean
 	-@for a in $(SUBDIRS) src/scrkit include help startup  plugins \
   packages; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a  $@ ; \
 	done
 	-@rm -f bin/*.o Makefile
 
diff --git a/xt_base/Makefile.in b/xt_base/Makefile.in
index 8eecd7c7..122ecdcf 100644
--- a/xt_base/Makefile.in
+++ b/xt_base/Makefile.in
@@ -29,27 +29,27 @@ SUBDIRS = \
   $(MALLOC_DIR) \
   $(REGEX_DIR)
 
-all: 
+all:
 	@if [ ! -d lib ]; then \
 	    mkdir lib; \
 	fi
 	@for a in $(SUBDIRS); do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE)) \
+	        $(MAKE) -C $$a ; \
 	    fi; \
 	done
-	
+
 depend clean:
 	-@for a in $(SUBDIRS); do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE) $@) \
+	        $(MAKE) -C $$a  $@ ; \
 	    fi; \
 	done
 
 distclean:
 	-@for a in $(SUBDIRS) packages; do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE) $@) \
+	        $(MAKE) -C $$a  $@ ; \
 	    fi; \
 	done
 	-@rm -f config.cache config.log config.status configure Makefile
-- 
2.34.1
```

