### PR TITLE
Makefile.in modifications to keep the directory output consistent (cd <dir> ; make <target>) => $(MAKE) -C <dir> <target>

### DIFF
--- a/KLU/Makefile.in
+++ b/KLU/Makefile.in
@@ -153,7 +153,7 @@ $(SHLIB_TARGET): AMD/Lib/libamd.a BTF/Lib/libbtf.a COLAMD/Lib/libcolamd.a \
 	    $(CC) -o $(SHLIB_TARGET) $(LSHFLAG) \
  $(OFILES_AMD) $(OFILES_BTF) $(OFILES_COLAMD) $(OFILES_KLU) \
  SuiteSparse_config/SuiteSparse_config.o;
-	
+
 unpack:
 	-@rm -rf AMD BTF COLAMD KLU SuiteSparse_config
 	@tar xzf SuiteSparse-$(SSVERSION).tar.gz
@@ -170,27 +170,27 @@ patch: unpack
 depend: unpack patch
 
 AMD/Lib/libamd.a ::
-	@cd AMD/Lib; $(MAKE) CC="$(CC)" CF="$(CFLAGS)"
+	@$(MAKE) -C AMD/Lib CC="$(CC)" CF="$(CFLAGS)"
 
 BTF/Lib/libbtf.a ::
-	@cd BTF/Lib; $(MAKE) CC="$(CC)" CF="$(CFLAGS)"
+	@$(MAKE) -C BTF/Lib CC="$(CC)" CF="$(CFLAGS)"
 
 COLAMD/Lib/libcolamd.a ::
-	@cd COLAMD/Lib; $(MAKE) CC="$(CC)" CF="$(CFLAGS)"
+	@$(MAKE) -C COLAMD/Lib CC="$(CC)" CF="$(CFLAGS)"
 
 KLU/Lib/libklu.a ::
-	@cd KLU/Lib; $(MAKE) CC="$(CC)" CF="$(CFLAGS)"
+	@$(MAKE) -C KLU/Lib CC="$(CC)" CF="$(CFLAGS)"
 
 SuiteSparse_config/SuiteSparse_config.o : \
  SuiteSparse_config/SuiteSparse_config.c
 	$(CC) $(CFLAGS) -c SuiteSparse_config/SuiteSparse_config.c -o $@
 
 clean:
-	-@cd AMD;  $(MAKE) distclean
-	-@cd BTF;  $(MAKE) distclean
-	-@cd COLAMD;  $(MAKE) distclean
-	-@cd KLU;  $(MAKE) distclean
-	-@cd SuiteSparse_config;  $(MAKE) distclean
+	-@$(MAKE) -C AMD distclean
+	-@$(MAKE) -C BTF distclean
+	-@$(MAKE) -C COLAMD distclean
+	-@$(MAKE) -C KLU distclean
+	-@$(MAKE) -C SuiteSparse_config distclean
 
 distclean:
 	-@rm -rf AMD BTF COLAMD KLU SuiteSparse_config

--- a/adms/Makefile.in
+++ b/adms/Makefile.in
@@ -30,7 +30,7 @@ REGEN = no
 
 all: unpack
 	@if [ -f adms_wr/admsXml/Makefile ]; then \
-	    cd adms_wr/admsXml; $(MAKE); \
+	    $(MAKE) -C adms_wr/admsXml ; \
 	else \
 	    echo "ADMS configuration failed. cleaning..."; \
 	    rm -rf adms_wr; \
@@ -65,12 +65,12 @@ unpack:
 
 clean:
 	-@if [ -d adms_wr ]; then \
-	    cd adms_wr/admsXml; $(MAKE) $@; \
+	    $(MAKE) -C adms_wr/admsXml $@; \
 	fi
 
 distclean:
 	-@rm -rf adms_wr Makefile
-	-@cd packages; $(MAKE) $@
+	-@$(MAKE) -C packages $@
 
 depend: unpack
 
@@ -184,6 +184,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/fastcap/Makefile.in
+++ b/fastcap/Makefile.in
@@ -28,8 +28,8 @@ IDSTR := \"`./release.sh` `$(BASE)/info.sh osname` `$(BASE)/info.sh arch`\"
 VERS := \"`./release.sh` (xictools)\"
 
 all: unpack
-	cd $(FASTCAP_DIR); $(MAKE) CC="$(CC)" all
-	cd fc_accs; $(MAKE) all
+	$(MAKE) -C $(FASTCAP_DIR) CC="$(CC)" all
+	$(MAKE) -C fc_accs all
 
 unpack:
 	@if [ ! -d $(FASTCAP_DIR) ]; then \
@@ -45,17 +45,17 @@ unpack:
 
 clean:
 	-@if [ -d $(FASTCAP_DIR) ]; then \
-	    cd $(FASTCAP_DIR); $(MAKE) $@; \
+	    $(MAKE) -C $(FASTCAP_DIR) $@; \
 	fi
-	-@cd fc_accs; $(MAKE) $@
+	-@$(MAKE) -C fc_accs $@
 
 distclean:
 	-@rm -rf $(FASTCAP_DIR) Makefile
-	-@cd fc_accs; $(MAKE) $@
-	-@cd packages; $(MAKE) $@
+	-@$(MAKE) -C fc_accs $@
+	-@$(MAKE) -C packages $@
 
 depend:
-	@cd fc_accs; $(MAKE) $@
+	@$(MAKE) -C fc_accs $@
 
 #######################################################################
 ####### Installation ##################################################
@@ -153,6 +153,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/fastcap/fc_accs/Makefile.in
+++ b/fastcap/fc_accs/Makefile.in
@@ -47,9 +47,9 @@ lstunpack: lstunpack.cc
 ####### Recursively generate libraries ################################
 
 $(BASE)/lib/miscutil.a::
-	cd $(BASE)/miscutil; $(MAKE)
+	$(MAKE) -C $(BASE)/miscutil
 	if [ x$(NTREGEX) != x ]; then \
-	    cd $(BASE)/miscutil/libregex; $(MAKE); \
+	    $(MAKE) -C $(BASE)/miscutil/libregex ; \
 	fi
 
 #######################################################################

--- a/fasthenry/Makefile.in
+++ b/fasthenry/Makefile.in
@@ -31,9 +31,9 @@ VERS := \"`./release.sh`\"
 all: unpack
 	# Make the KLU version since it is faster.
 	if [ ! -f ../KLU/KLU/Lib/libklu.a ]; then \
-	    cd ../KLU; $(MAKE); \
+	    $(MAKE) -C ../KLU ; \
         fi
-	cd $(FASTHENRY_DIR); $(MAKE) SOLVER=KLU_SOLVER CC="$(CC)" all
+	$(MAKE) -C $(FASTHENRY_DIR) SOLVER=KLU_SOLVER CC="$(CC)" all
 
 unpack:
 	@if [ ! -d $(FASTHENRY_DIR) ]; then \
@@ -54,12 +54,12 @@ unpack:
 
 clean:
 	-@if [ -d $(FASTHENRY_DIR) ]; then \
-	    cd $(FASTHENRY_DIR); $(MAKE) $@; \
+	    $(MAKE) -C $(FASTHENRY_DIR) $@; \
 	fi
 
 distclean:
 	-@rm -rf $(FASTHENRY_DIR) Makefile
-	-@cd packages; $(MAKE) $@
+	-@$(MAKE) -C packages $@
 
 depend:
 
@@ -158,6 +158,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/mozy/Makefile.in
+++ b/mozy/Makefile.in
@@ -105,34 +105,34 @@ bin/xeditor.o: bin/xeditor.cc
 ####### Recursively generate libraries ################################
 
 lib/$(GRPREF)mozy.a::
-	cd src/$(GRPREF)mozy; $(MAKE)
+	$(MAKE) -C src/$(GRPREF)mozy
 
 lib/help.a::
-	cd src/help; $(MAKE)
+	$(MAKE) -C src/help
 
 lib/htm.a::
-	cd src/htm; $(MAKE)
+	$(MAKE) -C src/htm
 
 lib/httpget.a::
-	cd src/httpget; $(MAKE)
+	$(MAKE) -C src/httpget
 
 lib/imsave.a::
-	cd src/imsave; $(MAKE)
+	$(MAKE) -C src/imsave
 
 $(BASE)/lib/ginterf.a::
-	cd $(BASE)/ginterf; $(MAKE)
+	$(MAKE) -C $(BASE)/ginterf
 
 $(BASE)/lib/$(GRPREF)interf.a::
-	cd $(BASE)/$(GRPREF)interf; $(MAKE)
+	$(MAKE) -C $(BASE)/$(GRPREF)interf
 
 $(BASE)/lib/miscutil.a::
-	cd $(BASE)/miscutil; $(MAKE)
+	$(MAKE) -C $(BASE)/miscutil
 
 $(BASE)/lib/libregex.a::
-	cd $(BASE)/regex; $(MAKE)
+	$(MAKE) -C $(BASE)/regex
 
 foo $(MOZYRES) $(XEDRES):
-	cd $(@D); $(MAKE) $(@F)
+	$(MAKE) -C $(@D) $(@F)
 
 #######################################################################
 ####### Dependencies in this directory ################################
@@ -150,7 +150,7 @@ depend::
 	    done; \
 	fi
 	@for a in $(SUBDIRS); do \
-	  (cd $$a; $(MAKE) depend) \
+	  $(MAKE) -C $$a depend; \
 	done
 
 #######################################################################
@@ -164,15 +164,15 @@ eclean::
 clean:: eclean
 	-@rm -f bin/*.o
 	-@for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a $@; \
 	done
 
 distclean:: eclean
 	-@rm -f bin/*.o Makefile
 	-@for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) distclean) \
+	    $(MAKE) -C $$a distclean; \
 	done
-	-@cd packages; $(MAKE) $@
+	-@$(MAKE) -C packages $@
 
 #######################################################################
 ####### Installation ##################################################
@@ -212,7 +212,7 @@ $(dst_lib)/mozy/startup::
 
 $(dst_lib)/mozy/help::
 	if [ -f help/Makefile ]; then \
-	    (cd help; $(MAKE)); \
+	    $(MAKE) -C help ; \
 	fi
 	@$(BASE)/util/mkdirpth $@
 	help=`packages/util/mozy_files help`; \
@@ -246,6 +246,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/mrouter/Makefile.in
+++ b/mrouter/Makefile.in
@@ -29,8 +29,8 @@ DEFLIB = source.lefdef/def_5.8-p013-wr.tar.gz
 LEFLIB = source.lefdef/lef_5.8-p013-wr.tar.gz
 
 all: lef def
-	@cd def; $(MAKE) CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
-	@cd lef; $(MAKE) CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
+	@$(MAKE) -C def CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
+	@$(MAKE) -C lef CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
 	@cd mrouter; $(MAKE) depend; $(MAKE)
 
 lef:
@@ -40,32 +40,32 @@ def:
 	@tar xzf $(DEFLIB)
 
 cleanlef:
-	@cd lef; $(MAKE) clean
+	@$(MAKE) -C lef clean
 
 cleandef:
-	@cd def; $(MAKE) clean
+	@$(MAKE) -C def clean
 
 buildlef:
-	@cd lef; $(MAKE) CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
+	@$(MAKE) -C lef CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
 
 builddef:
-	@cd def; $(MAKE) CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
+	@$(MAKE) -C def CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CFLAGS)"
 
 clean:
 	-@for a in $(SUBDIRS); do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE) clean); \
+	        $(MAKE) -C $$a clean; \
 	    fi \
 	done
-	-@cd examples; $(MAKE) clean
+	-@$(MAKE) -C examples clean
 
 distclean:
 	-@rm -rf lef def autom4te.cache config.cache config.status config.log \
   Makefile
 	-@rm -f mrouter-`./release.sh`.tar.gz
-	-@cd mrouter; $(MAKE) $@
-	-@cd examples; $(MAKE) $@
-	-@cd packages; $(MAKE) $@
+	-@$(MAKE) -C mrouter $@
+	-@$(MAKE) -C examples $@
+	-@$(MAKE) -C packages $@
 
 depend:
 	@if [ ! -d lef ]; then \
@@ -74,11 +74,11 @@ depend:
 	@if [ ! -d def ]; then \
 	    $(MAKE) def; \
 	fi
-	@cd mrouter; $(MAKE) $@
-	@cd examples; $(MAKE) $@
+	@$(MAKE) -C mrouter $@
+	@$(MAKE) -C examples $@
 
 test:
-	-cd mrouter; $(MAKE) test
+	-$(MAKE) -C mrouter test
 
 #######################################################################
 ####### Install programs into system location #########################
@@ -178,6 +178,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/mrouter/mrouter/Makefile.in
+++ b/mrouter/mrouter/Makefile.in
@@ -53,10 +53,10 @@ $(LIB_TARGET): $(MR_VERS_H) $(LDDBLIB) $(CCOBJS)
 	@$(CXX) $(LSHFLAG) -o $(LIB_TARGET) $(CCOBJS) $(TLIBS)
 
 $(LDDBLIB)::
-	cd ../lddb; $(MAKE)
+	$(MAKE) -C ../lddb
 
 $(BASE)/lib/miscutil.a::
-	(cd $(BASE)/miscutil; $(MAKE))
+	$(MAKE) -C $(BASE)/miscutil
 
 mrouter: $(MR_VERS_H) ../lddb/liblddb.a main.cc $(CCOBJS) \
   $(BASE)/lib/miscutil.a
@@ -74,7 +74,7 @@ $(MR_VERS_H):
 	$(CXX) $(CFLAGS) $(PIC_OPT) $(INCLUDE) -c $*.cc
 
 depend: $(MR_VERS_H)
-	cd ../lddb; $(MAKE) depend
+	$(MAKE) -C ../lddb depend
 	@echo depending in $(LOCATION)
 	@if [ x$(DEPEND_DONE) = x ]; then \
 	    echo DEPEND_DONE = 1 >> Makefile; \
@@ -82,15 +82,15 @@ depend: $(MR_VERS_H)
 	fi
 
 clean:
-	-@cd ../lddb; $(MAKE) $@
+	-@$(MAKE) -C ../lddb $@
 	-@rm -f $(MR_VERS_H) *.o $(LIB_TARGET) mrouter$(EXESUFFIX)
 
 distclean:
-	-@cd ../lddb; $(MAKE) $@
-	-@cd test; $(MAKE) $@
+	-@$(MAKE) -C ../lddb $@
+	-@$(MAKE) -C test $@
 	-@rm -f $(MR_VERS_H) *.o $(LIB_TARGET) Makefile mrouter$(EXESUFFIX)
 
 test: mrouter
-	cd test; $(MAKE) test1
+	$(MAKE) -C test test1
 
 #######################################################################

--- a/secure/Makefile.in
+++ b/secure/Makefile.in
@@ -81,7 +81,7 @@ xtlserv: xtlserv.o $(BASE)/lib/miscutil.a
   $(BASE)/lib/miscutil.a $(SLIBS) $(STDCLIB)
 
 $(BASE)/lib/miscutil.a::
-	cd $(BASE)/miscutil; $(MAKE)
+	$(MAKE) -C $(BASE)/miscutil
 
 DARGS = \
   -DPREFIX="\"$(prefix)\"" \
@@ -115,7 +115,7 @@ clean: eclean
 	-@rm *.o $(LIB_TARGET)
 
 distclean: clean
-	-@cd packages; $(MAKE) $@
+	-@$(MAKE) -C packages $@
 	-@rm -f LICENSE* Makefile validate.log xtdaemon.log
 
 INSTALL_PREFIX ?= $(prefix)
@@ -158,6 +158,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/vl/Makefile.in
+++ b/vl/Makefile.in
@@ -64,15 +64,15 @@ $(LIB_TARGET): $(COBJS)
 
 $(BASE)/lib/miscutil.a::
 	if [ -d $(BASE)/miscutil ]; then \
-	    cd $(BASE)/miscutil; $(MAKE); \
+	    $(MAKE) -C $(BASE)/miscutil ; \
 	fi
 
 clean:
-	-@cd test; $(MAKE) $@
+	-@$(MAKE) -C test $@
 	-@rm -f *.o *.a vl$(EXESUFFIX)
 
 distclean: clean
-	-@cd packages; $(MAKE) $@
+	-@$(MAKE) -C packages $@
 	-@rm -f verilog_yacc.cc verilog_yacc.h verilog_lex.cc
 	-@rm -f config.cache config.h config.log config.status Makefile
 
@@ -102,7 +102,7 @@ depend:
 	fi
 
 test::
-	-@cd test; $(MAKE) $@
+	-@$(MAKE) -C test $@
 
 #######################################################################
 ####### Installation ##################################################
@@ -154,6 +154,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/wrspice/Makefile.in
+++ b/wrspice/Makefile.in
@@ -119,12 +119,12 @@ MMJCO = mmjco/mmjco
 all: cptest $(TARGETS) $(MMJCO) wdemo
 
 cptest:
-	cd help; make cptest
-	cd ipc_demo; make cptest
-	cd src/misc; make cptest
-	cd src/sparse; make cptest
-	cd devlib/include; make cptest
-	cd devlib/adms/include; make cptest
+	$(MAKE) -C help cptest
+	$(MAKE) -C ipc_demo cptest
+	$(MAKE) -C src/misc cptest
+	$(MAKE) -C src/sparse cptest
+	$(MAKE) -C devlib/include cptest
+	$(MAKE) -C devlib/adms/include cptest
 
 # Target to edit ADMS files for correct SyntaxLevel (same as release level).
 syntaxlevel:
@@ -190,67 +190,67 @@ bin/printtoraw: bin/printtoraw.o $(BASE)/lib/miscutil.a
   $(STDCLIB) $(WINPTHREADFIX)
 
 mmjco/mmjco::
-	cd mmjco; make
+	$(MAKE) -C mmjco
 
 #######################################################################
 ####### Recursively generate libraries ################################
 
 $(DEVLIB_CALL)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 $(SUBDIR_LIBS)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 $(VLOG)::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 
 ifeq ($(USESECURE), yes)
 $(SECURE)/secure.a::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 endif
 
 $(MALLOC)::
-	cd $(@D)/../malloc; $(MAKE)
+	$(MAKE) -C $(@D)/../malloc
 
 $(BASE)/lib/ginterf.a::
-	cd $(BASE)/ginterf; $(MAKE)
+	$(MAKE) -C $(BASE)/ginterf
 
 ifdef GRPREF
 $(BASE)/lib/$(GRPREF)interf.a::
-	cd $(BASE)/$(GRPREF)interf; $(MAKE)
+	$(MAKE) -C $(BASE)/$(GRPREF)interf
 endif
 
 $(BASE)/lib/miscutil.a::
-	cd $(BASE)/miscutil; $(MAKE)
+	$(MAKE) -C $(BASE)/miscutil
 
 $(BASE)/lib/libregex.a::
-	cd $(BASE)/regex; $(MAKE)
+	$(MAKE) -C $(BASE)/regex
 
 ifdef GRPREF
 ifeq ($(USEMOZY), yes)
 $(MOZY)/lib/$(GRPREF)mozy.a::
 	if [ -d $(MOZY)/src/$(GRPREF)mozy ]; then \
-	    cd $(MOZY)/src/$(GRPREF)mozy; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/$(GRPREF)mozy ; \
 	fi
 
 $(MOZY)/lib/help.a::
 	if [ -d $(MOZY)/src/help ]; then \
-	    cd $(MOZY)/src/help; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/help ; \
 	fi
 
 $(MOZY)/lib/htm.a::
 	if [ -d $(MOZY)/src/htm ]; then \
-	    cd $(MOZY)/src/htm; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/htm ; \
 	fi
 
 $(MOZY)/lib/httpget.a::
 	if [ -d $(MOZY)/src/httpget ]; then \
-	    cd $(MOZY)/src/httpget; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/httpget ; \
 	fi
 
 $(MOZY)/lib/imsave.a::
 	if [ -d $(MOZY)/src/imsave ] ; then \
-	    cd $(MOZY)/src/imsave; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/imsave ; \
 	fi
 endif
 endif
@@ -305,9 +305,9 @@ CCFILES = bin/wrspice.cc bin/wrspiced.cc bin/multidec.cc bin/proc2mod.cc \
   bin/printtoraw.cc
 
 depend: syntaxlevel
-	@(cd devlib/adms/examples; $(MAKE) make);
+	@$(MAKE) -C devlib/adms/examples make ;
 	@for a in include $(SUBDIRS) devlib help startup; do \
-	    (cd $$a; $(MAKE) depend) \
+	    $(MAKE) -C $$a depend; \
 	done
 	@echo depending in $(LOCATION)
 	@if [ x$(DEPEND_DONE) = x ]; then \
@@ -333,26 +333,26 @@ eclean:
 
 clean: eclean
 	-@for a in $(SUBDIRS) devlib; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a $@; \
 	done
-	cd mmjco; $(MAKE) clean
+	$(MAKE) -C mmjco clean
 	-@rm -f bin/*.o $(WDEMODIR).tar.gz
 
 distclean: eclean
 	-@for a in $(SUBDIRS) include devlib packages help startup \
   ipc_demo_files; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a $@; \
 	done
-	-@cd mmjco; $(MAKE) distclean
+	-@$(MAKE) -C mmjco distclean
 	-@rm -f bin/*.o wrspice_ipc_demo.tar.gz Makefile
 	-@rm -f examples/wrspice_ipc_demo.tar.gz
 	-@rm -f devlib/adms/admst/device.xml
 
 ifdef GRPREF
 grclean:
-	cd src/$(GRPREF)wrs; $(MAKE) clean
-	cd ../mozy/src/$(GRPREF)mozy; $(MAKE) clean
-	cd ../xt_base/$(GRPREF)interf; $(MAKE) clean
+	$(MAKE) -C src/$(GRPREF)wrs clean
+	$(MAKE) -C ../mozy/src/$(GRPREF)mozy clean
+	$(MAKE) -C ../xt_base/$(GRPREF)interf clean
 endif
 
 #######################################################################
@@ -506,7 +506,7 @@ $(destn)/icons::
 	done
 
 $(destn)/help::
-	cd help; $(MAKE)
+	$(MAKE) -C help
 	@$(BASE)/util/mkdirpth $@ $@/screenshots
 	help=`packages/util/wrspice_files help`; \
 	for a in $$help; do \
@@ -519,7 +519,7 @@ $(destn)/help::
 	done
 
 $(destn)/startup::
-	cd startup; $(MAKE)
+	$(MAKE) -C startup
 	@$(BASE)/util/mkdirpth $@
 	startup=`packages/util/wrspice_files startup`; \
 	for a in $$startup; do \
@@ -611,7 +611,7 @@ $(destn)/cadence-oasis::
 devkit_examples:
 	(cd devlib/adms/examples; \
 	    for a in */Makefile; do \
-	        (cd `dirname $$a`; $(MAKE) \
+	        $(MAKE) -C `dirname $$a` \
 	            ADMST=../../admst \
 	            ADMSXML=../../../../../adms/adms_wr/admsXml/admsXml \
 	            DLL_LOC=../../../../bin \
@@ -631,6 +631,6 @@ package::
 	if [ -n "$(TKTOOLS)" ]; then \
 	    $(MAKE) INSTALL_PREFIX=packages/root$(prefix) install_cadence; \
 	fi
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/wrspice/devlib/Makefile.in
+++ b/wrspice/devlib/Makefile.in
@@ -80,14 +80,14 @@ DEVOBJS = $(SUBDIRS:=/*.o)
 ####### Library targets ###############################################
 
 dummy:
-	-@cd include; $(MAKE)
-	-@cd adms/include; $(MAKE)
+	-@$(MAKE) -C include
+	-@$(MAKE) -C adms/include
 	@echo Making device library;
 	$(MAKE) $(LIB_TARGET);
 
 veriloga:
-	-@cd adms/include; $(MAKE)
-	-@cd adms/examples; $(MAKE)
+	-@$(MAKE) -C adms/include
+	-@$(MAKE) -C adms/examples
 
 $(LIB_TARGET): subdirs $(COBJS)
 	@if [ -f $(LIB_TARGET) ]; then \
@@ -144,7 +144,7 @@ toc.so: toc.cc
 
 subdirs:
 	for a in $(SUBDIRS); do \
-	    (cd $$a; $(MAKE)); \
+	    $(MAKE) -C $$a ; \
 	done;
 
 #######################################################################
@@ -153,7 +153,7 @@ subdirs:
 
 depend:
 	-@for a in include adms/include $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) depend;) \
+	    $(MAKE) -C $$a depend; \
 	done
 	@echo depending in devlib
 	-@if [ x$(DEPEND_DONE) = x ]; then \
@@ -168,13 +168,13 @@ depend:
 
 clean:
 	-@for a in adms/examples $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a $@; \
 	done
 	-@rm -f toc.cc *.o *.a
 
 distclean:
 	-@for a in include adms/include adms/examples  $(SUBDIRS); do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a $@; \
 	done
 	-@rm -f toc.cc *.o *.a Makefile devices modules
 	-@rm -f adms/Makefile

--- a/wrspice/mmjco/Makefile.in
+++ b/wrspice/mmjco/Makefile.in
@@ -48,10 +48,10 @@ mmjco_tscale.o: mmjco_tscale.cc mmjco_tscale.h
 	g++ $(CFLAGS) $(INCLUDE) -c mmjco_tscale.cc
 
 ./cmpfit-1.4/libmpfit.a:
-	cd cmpfit-1.4; $(MAKE)
+	$(MAKE) -C cmpfit-1.4
 
 clean::
-	-@cd cmpfit-1.4; $(MAKE) clean
+	-@$(MAKE) -C cmpfit-1.4 clean
 	-@rm -f libmmjco.a *.o mmjco mmjco.exe tca* tempr tempr.exe
 
 distclean: clean

--- a/xic/Makefile.in
+++ b/xic/Makefile.in
@@ -111,9 +111,9 @@ TARGETS = xic wrencode wrdecode wrsetpass
 all:  cptest $(TARGETS) plugins
 
 cptest:
-	cd help; make cptest
-	cd src/sparse; make cptest
-	cd src/wrspif; make cptest
+	$(MAKE) -C help cptest
+	$(MAKE) -C src/sparse cptest
+	$(MAKE) -C src/wrspif cptest
 
 $(TARGETS)::
 	$(MAKE) bin/$@
@@ -141,7 +141,7 @@ bin/xic: bin/xic.o $(LOCAL_LIBS) $(MALLOC) $(OA_SUBDIR)
 endif
 
 plugins::
-	cd plugins; $(MAKE)
+	$(MAKE) -C plugins
 
 # sa-filetool will always rebuild fietool.o, to set a three-month lifetime
 # for the binary.
@@ -176,7 +176,7 @@ bin/wrdecode: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a
 	$(LINKCC) $(CFLAGS) -o bin/wrdecode $(INCLUDE) bin/cryptmain.cc \
   src/parser/parser.a $(BASE)/lib/miscutil.a  $(STDCLIB) $(WINPTHREADFIX)
 
-bin/wrsetpass: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a 
+bin/wrsetpass: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a
 	$(LINKCC) $(CFLAGS) -o bin/wrsetpass $(INCLUDE) -DENCODING -DSETPASS \
   bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a $(STDCLIB) \
   $(WINPTHREADFIX)
@@ -186,58 +186,58 @@ bin/wrsetpass: bin/cryptmain.cc src/parser/parser.a $(BASE)/lib/miscutil.a
 
 $(SUBDIR_LIBS) $(OA_SUBDIR)::
 	@if [ x$@ = x$(OA_SUBDIR) ]; then \
-	    cd $(OA_SUBDIR); $(MAKE); \
+	    $(MAKE) -C $(OA_SUBDIR) ; \
 	else \
-	    cd $(@D); $(MAKE); \
+	    $(MAKE) -C $(@D) ; \
 	fi
 
 ifeq ($(USESECURE), yes)
 $(SECURE)/secure.a::
-	cd $(@D); $(MAKE)
+	$(MAKE) -C $(@D)
 endif
 
 $(MALLOC)::
-	cd $(@D)/../malloc; $(MAKE)
+	$(MAKE) -C $(@D)/../malloc
 
 $(BASE)/lib/ginterf.a::
-	cd $(BASE)/ginterf; $(MAKE)
+	$(MAKE) -C $(BASE)/ginterf
 
 ifdef GRPREF
 $(BASE)/lib/$(GRPREF)interf.a::
-	cd $(BASE)/$(GRPREF)interf; $(MAKE)
+	$(MAKE) -C $(BASE)/$(GRPREF)interf
 endif
 
 $(BASE)/lib/miscutil.a::
-	cd $(BASE)/miscutil; $(MAKE)
+	$(MAKE) -C $(BASE)/miscutil
 
 $(BASE)/lib/libregex.a::
-	cd $(BASE)/regex; $(MAKE)
+	$(MAKE) -C $(BASE)/regex
 
 ifdef GRPREF
 ifeq ($(USEMOZY), yes)
 $(MOZY)/lib/$(GRPREF)mozy.a::
 	if [ -d $(MOZY)/src/$(GRPREF)mozy ]; then \
-	    cd $(MOZY)/src/$(GRPREF)mozy; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/$(GRPREF)mozy ; \
 	fi
 
 $(MOZY)/lib/help.a::
 	if [ -d $(MOZY)/src/help ]; then \
-	    cd $(MOZY)/src/help; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/help ; \
 	fi
 
 $(MOZY)/lib/htm.a::
 	if [ -d $(MOZY)/src/htm ]; then \
-	    cd $(MOZY)/src/htm; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/htm ; \
 	fi
 
 $(MOZY)/lib/httpget.a::
 	if [ -d $(MOZY)/src/httpget ]; then \
-	    cd $(MOZY)/src/httpget; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/httpget ; \
 	fi
 
 $(MOZY)/lib/imsave.a::
 	if [ -d $(MOZY)/src/imsave ] ; then \
-	    cd $(MOZY)/src/imsave; $(MAKE); \
+	    $(MAKE) -C $(MOZY)/src/imsave ; \
 	fi
 endif
 endif
@@ -278,7 +278,7 @@ CCFILES = bin/xic.cc bin/sa-filetool.cc bin/cryptmain.cc
 
 depend:
 	@for a in include $(SUBDIRS) help startup plugins; do \
-	    (cd $$a; $(MAKE) depend) \
+	    $(MAKE) -C $$a depend; \
 	done
 	@echo depending in $(LOCATION)
 	@if [ x$(DEPEND_DONE) = x ]; then \
@@ -304,22 +304,22 @@ eclean:
 
 clean: eclean
 	-@for a in $(SUBDIRS) plugins; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a $@; \
 	done
 	-@rm -f bin/*.o
 
 distclean: eclean
 	-@for a in $(SUBDIRS) src/scrkit include help startup  plugins \
   packages; do \
-	    (cd $$a; $(MAKE) $@) \
+	    $(MAKE) -C $$a $@; \
 	done
 	-@rm -f bin/*.o Makefile
 
 ifdef GRPREF
 grclean:
-	cd src/$(GRPREF)xic; $(MAKE) clean
-	cd ../mozy/src/$(GRPREF)mozy; $(MAKE) clean
-	cd ../xt_base/$(GRPREF)interf; $(MAKE) clean
+	$(MAKE) -C src/$(GRPREF)xic clean
+	$(MAKE) -C ../mozy/src/$(GRPREF)mozy clean
+	$(MAKE) -C ../xt_base/$(GRPREF)interf clean
 endif
 
 #######################################################################
@@ -427,7 +427,7 @@ $(destn)/bin::
 	@$(BASE)/util/mkdirpth $(toolbin)
 
 $(destn)/help::
-	cd help; $(MAKE)
+	$(MAKE) -C help
 	@$(BASE)/util/mkdirpth $@ $@/screenshots
 	help=`packages/util/xic_files help`; \
         for a in $$help; do \
@@ -458,7 +458,7 @@ $(destn)/plugins::
 	fi
 
 $(destn)/startup::
-	cd startup; $(MAKE)
+	$(MAKE) -C startup
 	@$(BASE)/util/mkdirpth $@
 	startup=`packages/util/xic_files startup`; \
 	for a in $$startup; do \
@@ -517,6 +517,6 @@ package::
 	-rm -rf packages/root
 	mkdir packages/root
 	$(MAKE) INSTALL_PREFIX=packages/root$(prefix) install_xic_pkg
-	cd packages; $(MAKE) package
+	$(MAKE) -C packages package
 
 #######################################################################

--- a/xt_base/Makefile.in
+++ b/xt_base/Makefile.in
@@ -33,27 +33,27 @@ SUBDIRS = \
   $(MALLOC_DIR) \
   $(REGEX_DIR)
 
-all: 
+all:
 	@if [ ! -d lib ]; then \
 	    mkdir lib; \
 	fi
 	@for a in $(SUBDIRS); do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE)) \
+	        $(MAKE) -C $$a ; \
 	    fi; \
 	done
-	
+
 depend clean:
 	-@for a in $(SUBDIRS); do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE) $@) \
+	        $(MAKE) -C $$a $@; \
 	    fi; \
 	done
 
 distclean:
 	-@for a in $(SUBDIRS) packages; do \
 	    if [ -d $$a ]; then \
-	        (cd $$a; $(MAKE) $@) \
+	        $(MAKE) -C $$a $@; \
 	    fi; \
 	done
 	-@rm -f config.cache config.log config.status configure Makefile


### PR DESCRIPTION
…to $(MAKE) -C <dir> <target>

I used an elisp set of functions to update the Makefile.in's with this change.  I have run the make reconfig, make all, make packages, make devclean, and I think that it is working. watches the continued likes and shell variables.

I posted the elisp in gist https://gist.github.com/ElderDelp/ce175e8e07cf95b92e36ea3e3614604e